### PR TITLE
possibly fixed rpy interpretation

### DIFF
--- a/novatel_span_driver/src/novatel_span_driver/publisher.py
+++ b/novatel_span_driver/src/novatel_span_driver/publisher.py
@@ -194,10 +194,9 @@ class NovatelPublisher(object):
         # Save this on an instance variable, so that it can be published
         # with the IMU message as well.
         self.orientation = tf.transformations.quaternion_from_euler(
-            radians(inspvax.pitch),
-            radians(inspvax.roll),
-            radians(90 - inspvax.azimuth))
-        print inspvax.azimuth
+                radians(inspvax.roll),
+                radians(inspvax.pitch),
+                -radians(inspvax.azimuth), 'syxz'))
         odom.pose.pose.orientation = Quaternion(*self.orientation)
         odom.pose.covariance[21] = self.orientation_covariance[0] = pow(2, inspvax.pitch_std)
         odom.pose.covariance[28] = self.orientation_covariance[4] = pow(2, inspvax.roll_std)


### PR DESCRIPTION
Hi, @mikepurvis could you please take a look?

As mentioned in issue #6, this is how we are interpreting the INSPVA roll, pitch and azimuth. This fix works well in our application and it seems to go well with the orientation order of z-x-y and azimuth as the left-hand rotation from http://www.novatel.com/assets/Documents/Bulletins/apn037.pdf
