### PR TITLE
Add support to serial connection

### DIFF
--- a/memo.md
+++ b/memo.md
@@ -1,0 +1,8 @@
+# シリアル対応化作業用メモ
+### 通信用インスタンス
+通信のインスタンスは全部bridge.pyのsockを利用
+これをシリアル用のインスタンスに条件分岐させれば良さそう
+ただしport.pyで「except socket.timeout:」が利用されている
+#### メソッドの変更
+socket.recv() -> serial.read()
+socket.send() -> serial.write()

--- a/novatel_span_driver/launch/example_serial.launch
+++ b/novatel_span_driver/launch/example_serial.launch
@@ -1,0 +1,47 @@
+<launch>
+  <!-- <arg name="ip" default="198.161.73.9" /> -->
+  <arg name="serial_port" default="/dev/ttyUSB0" />
+  <arg name="serial_baud" default="9600" />
+
+  <node name="novatel_span_driver" pkg="novatel_span_driver" type="driver" output="screen">
+    <param name="serial_port" value="$(arg serial_port)" />
+    <param name="serial_baud" value="$(arg serial_baud)" />
+    <rosparam ns="configuration">
+      log_request:
+        inspvaxb: 1
+        bestposb: 1
+        corrimudatab: 1
+        inscovb: 1
+# The example setup commands below apply to a Clearpath Robotics Husky running
+# SPAN with dual antennas. Run the SPAN setup wizard on your own platform to generate
+# an appropriate config.
+#      command:
+#        connectimu: COM3 IMU_KVH_COTS
+#        setimuorientation: 5
+#        vehiclebodyrotation: 0.000000 0.000000 0.000000 0.000000 0.000000 0.000000
+#        applyvehiclebodyrotation: enable
+#        setimutoantoffset: -0.519200 -0.131500 0.258600 0.001000 0.001000 0.001000
+#        setimutoantoffset2: 0.580800 -0.131500 0.258600 0.001000 0.001000 0.001000
+#        setinsoffset: 0.030800 -0.294200 -0.104100
+#        alignmentmode: AUTOMATIC
+    </rosparam>
+
+    <!-- Whether or not the driver should publish a TF, and what frames it should
+         be between. This configuration publishes odom -> base_link. -->
+    <param name="publish_tf" value="true" />
+    <param name="odom_frame" value="odom" />
+    <param name="base_frame" value="base_link" />
+
+    <!-- IMU rate; controls scaling of the imu/data topic values. This is a
+         function of the underlying hardware IMU rate, which is 100Hz for IMU-CPT. -->
+    <param name="rate" value="100" />
+
+    <!-- Disable this if you don't want SPAN to use wheel encoder data. Remap the odom
+         topic if your encoders publish elsewhere. -->
+    <param name="enable_wheel_velocity" value="true" />
+
+    <!-- Disable this if you'd like the Odometry to be absolute within the UTM zone
+         rather than starting from an arbitrary zero origin. -->
+    <param name="zero_start" value="true" />
+  </node>
+</launch>

--- a/novatel_span_driver/launch/example_serial.launch
+++ b/novatel_span_driver/launch/example_serial.launch
@@ -1,0 +1,47 @@
+<launch>
+  <!-- <arg name="ip" default="198.161.73.9" /> -->
+  <arg name="serial_port" default="/dev/ttyUSB0" />
+  <arg name="serial_baud" default="9600" />
+
+  <node name="novatel_span_driver" pkg="novatel_span_driver" type="driver" output="screen">
+    <param name="serial_port" value="$(arg serial_port)" />
+    <param name="serial_baud" value="$(arg serial_baud)" />
+    <rosparam ns="configuration">
+      log_request:
+        inspvaxb: 0.5
+        bestposb: 0.5
+        corrimudatab: 0.5
+        inscovb: 1
+# The example setup commands below apply to a Clearpath Robotics Husky running
+# SPAN with dual antennas. Run the SPAN setup wizard on your own platform to generate
+# an appropriate config.
+#      command:
+#        connectimu: COM3 IMU_KVH_COTS
+#        setimuorientation: 5
+#        vehiclebodyrotation: 0.000000 0.000000 0.000000 0.000000 0.000000 0.000000
+#        applyvehiclebodyrotation: enable
+#        setimutoantoffset: -0.519200 -0.131500 0.258600 0.001000 0.001000 0.001000
+#        setimutoantoffset2: 0.580800 -0.131500 0.258600 0.001000 0.001000 0.001000
+#        setinsoffset: 0.030800 -0.294200 -0.104100
+#        alignmentmode: AUTOMATIC
+    </rosparam>
+
+    <!-- Whether or not the driver should publish a TF, and what frames it should
+         be between. This configuration publishes odom -> base_link. -->
+    <param name="publish_tf" value="true" />
+    <param name="odom_frame" value="odom" />
+    <param name="base_frame" value="base_link" />
+
+    <!-- IMU rate; controls scaling of the imu/data topic values. This is a
+         function of the underlying hardware IMU rate, which is 100Hz for IMU-CPT. -->
+    <param name="rate" value="100" />
+
+    <!-- Disable this if you don't want SPAN to use wheel encoder data. Remap the odom
+         topic if your encoders publish elsewhere. -->
+    <param name="enable_wheel_velocity" value="true" />
+
+    <!-- Disable this if you'd like the Odometry to be absolute within the UTM zone
+         rather than starting from an arbitrary zero origin. -->
+    <param name="zero_start" value="true" />
+  </node>
+</launch>

--- a/novatel_span_driver/launch/span_cpt.launch
+++ b/novatel_span_driver/launch/span_cpt.launch
@@ -1,0 +1,6 @@
+<launch>
+  <include file="$(find novatel_span_driver)/launch/example_serial.launch">
+    <arg name="serial_port" value="/dev/ttyUSB0" />
+    <arg name="serial_baud" value="9600" />
+  </include>
+</launch>

--- a/novatel_span_driver/src/novatel_span_driver/port.py
+++ b/novatel_span_driver/src/novatel_span_driver/port.py
@@ -35,11 +35,13 @@ from translator import Translator
 # Python
 import threading
 import socket
+import serial
 import struct
 from cStringIO import StringIO
 
 
 class Port(threading.Thread):
+
     """ Common base class for DataPort and ControlPort. Provides functionality to
       recv/send novatel-formatted packets from the socket. Could in future
       support LoggingPort and DisplayPort."""
@@ -69,7 +71,7 @@ class Port(threading.Thread):
                     bytes_before_sync = ''.join(bytes_before_sync)
                     if len(bytes_before_sync) > 0 and not bytes_before_sync.startswith("\r\n<OK"):
                         rospy.logwarn(("Discarded %d bytes between end of previous message " +
-                                      "and next sync byte.") % len(bytes_before_sync))
+                                       "and next sync byte.") % len(bytes_before_sync))
                         rospy.logwarn("Discarded: %s" % repr(bytes_before_sync))
                     break
                 bytes_before_sync.append(sync)
@@ -87,7 +89,7 @@ class Port(threading.Thread):
                 raise ValueError("Bad header length. Expected %d, got %d" %
                                  (header.translator().size, header_length))
 
-        except socket.timeout:
+        except (socket.timeout, serial.SerialTimeoutException) as e:
             return None, None
 
         header_str = self.sock.recv(header_length)


### PR DESCRIPTION
Add support to serial connection.
You can test by using example_serial.launch

There is new ros params,`~/ip_address`, `~/ip_port`, `~/serial_port` and `~/serial_baud`.
Connection priority is 
`ip_address`>`serial_port`>`ip(old param)`
There is remain `~/ip` param for backward compatible.
This struct is based on these
[[REP-138] LaserScan Common Topics, Parameters, and Diagnostic Keys](http://www.ros.org/reps/rep-0138.html)
[urg_node#Parameters](http://wiki.ros.org/urg_node#Parameters)

Because I don' have ethernet enabled NovAtel sensors, I cant debug socket and I didn't edit sequence around socket .
Now I using monkey patch, that make `serial` obj compatible to `socket` object.

Sorry about my poor English.
Thank you.
