### PR TITLE
gps_common/GPSFix support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.py[oc]
 *.sw[op]
+.idea/

--- a/novatel_span_driver/package.xml
+++ b/novatel_span_driver/package.xml
@@ -19,6 +19,7 @@
   <run_depend>diagnostic_msgs</run_depend>
   <run_depend>diagnostic_updater</run_depend>
   <run_depend>geodesy</run_depend>
+  <run_depend>gps_common</run_depend>
   <run_depend>novatel_msgs</run_depend>
   <run_depend>python-serial</run_depend>
   <run_depend>rospy</run_depend>

--- a/novatel_span_driver/src/novatel_span_driver/publisher.py
+++ b/novatel_span_driver/src/novatel_span_driver/publisher.py
@@ -327,7 +327,7 @@ class NovatelPublisher(object):
     def corrimudata_handler(self, corrimudata):
         # TODO: Work out these covariances properly. Logs provide covariances in local frame, not body
         imu = Imu()
-        imu.header.stamp == rospy.Time.now()
+        imu.header.stamp = rospy.Time.now()
         imu.header.frame_id = self.base_frame
 
         # Populate orientation field with one from inspvax message.


### PR DESCRIPTION
This adds support for publishing [gps_common/GPSFix](http://wiki.ros.org/gps_common) messages based on BESTPOS messages received from the NovAtel.

It also fixes an unrelated issue where the timestamp in the header of `sensor_msgs/Imu` messages was not being filled in properly.