### PR TITLE
Fix bad == when publishing IMU message

### DIFF
--- a/novatel_span_driver/src/novatel_span_driver/publisher.py
+++ b/novatel_span_driver/src/novatel_span_driver/publisher.py
@@ -228,7 +228,7 @@ class NovatelPublisher(object):
     def corrimudata_handler(self, corrimudata):
         # TODO: Work out these covariances properly. Logs provide covariances in local frame, not body
         imu = Imu()
-        imu.header.stamp == rospy.Time.now()
+        imu.header.stamp = rospy.Time.now()
         imu.header.frame_id = self.base_frame
 
         # Populate orientation field with one from inspvax message.


### PR DESCRIPTION
The use of `==` rather than `=` was causing the timestamp in the header to not be filled in properly.