### PR TITLE
Fix orthometric to ellipsoidal conversion

### DIFF
--- a/novatel_span_driver/src/novatel_span_driver/publisher.py
+++ b/novatel_span_driver/src/novatel_span_driver/publisher.py
@@ -159,7 +159,7 @@ class NovatelPublisher(object):
         navsat.longitude = bestpos.longitude
 
         # Altitude in metres.
-        navsat.altitude = bestpos.altitude
+        navsat.altitude = bestpos.altitude + bestpos.undulation
         navsat.position_covariance[0] = pow(2, bestpos.latitude_std)
         navsat.position_covariance[4] = pow(2, bestpos.longitude_std)
         navsat.position_covariance[8] = pow(2, bestpos.altitude_std)


### PR DESCRIPTION
Fix #26.

Switch NavSatFix altitude assignment to use conversion from orthometric height and undulation instead of direct assignment.