### PR TITLE
Deleted extra ')'

### DIFF
--- a/novatel_span_driver/src/novatel_span_driver/publisher.py
+++ b/novatel_span_driver/src/novatel_span_driver/publisher.py
@@ -196,7 +196,7 @@ class NovatelPublisher(object):
         self.orientation = tf.transformations.quaternion_from_euler(
                 radians(inspvax.roll),
                 radians(inspvax.pitch),
-                -radians(inspvax.azimuth), 'syxz'))
+                -radians(inspvax.azimuth), 'syxz')
         odom.pose.pose.orientation = Quaternion(*self.orientation)
         odom.pose.covariance[21] = self.orientation_covariance[0] = pow(2, inspvax.pitch_std)
         odom.pose.covariance[28] = self.orientation_covariance[4] = pow(2, inspvax.roll_std)


### PR DESCRIPTION
There was an extra ')' that prevented the driver from being used.